### PR TITLE
Pvdeh frontend

### DIFF
--- a/lib/Core/loadPlugins.ts
+++ b/lib/Core/loadPlugins.ts
@@ -18,7 +18,7 @@ async function loadPlugins(
   try {
     const pluginsList = getPluginsList();
     const loadPromises = pluginsList.map((promise) => {
-      const pluginContext = createPluginContext(viewState);
+      const pluginContext = createPluginContext(viewState, undefined);
       return promise
         .then(({ default: plugin }) => {
           try {

--- a/lib/Plugins/DynamicWmsPlugin.ts
+++ b/lib/Plugins/DynamicWmsPlugin.ts
@@ -1,20 +1,30 @@
 import { reaction } from "mobx";
-import { JulianDate } from "@cesium/engine";
-import CommonStrata from "terriajs/lib/Models/Definition/CommonStrata";
+import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
+import TerriaError from "terriajs/lib/Core/TerriaError";
+import { featureBelongsToCatalogItem } from "terriajs/lib/Map/PickedFeatures/PickedFeatures";
 import WebMapServiceCatalogItem from "terriajs/lib/Models/Catalog/Ows/WebMapServiceCatalogItem";
+import CommonStrata from "terriajs/lib/Models/Definition/CommonStrata";
 import type { TerriaPluginContext } from "terriajs-plugin-api";
 
 const DYNAMIC_WMS_ID = "__re100_dynamic_wms__";
 
+/** Feature attributes that map a clicked feature to a WMS layer. */
+const URL_ATTRIBUTE = "wms_url";
+const LAYER_ATTRIBUTE = "wms_layer";
+const NAME_ATTRIBUTE = "wms_name";
+
 export default {
   name: "DynamicWms",
   description:
-    "Loads a WMS layer into the workbench when a feature with a wms_url attribute is clicked, and removes it when another feature (without wms_url) is clicked.",
+    "Loads a WMS layer into the workbench when a feature with a wms_url attribute is clicked. Clicking a different feature swaps the WMS layer; clicking elsewhere removes it.",
   version: "1.0.0",
 
   register(ctx: TerriaPluginContext) {
     const { terria } = ctx;
     let currentItem: WebMapServiceCatalogItem | undefined;
+    // Incremented on every click so slow async work from an older click can
+    // detect it has been superseded and bail out.
+    let clickSeq = 0;
 
     function removeCurrent() {
       if (currentItem && terria.workbench.contains(currentItem)) {
@@ -22,44 +32,95 @@ export default {
       }
     }
 
+    async function onPickedFeatures(
+      pickedFeatures: typeof terria.pickedFeatures
+    ) {
+      const seq = ++clickSeq;
+
+      if (!pickedFeatures) {
+        // Feature info panel dismissed.
+        removeCurrent();
+        return;
+      }
+
+      // Features from imagery layers (e.g. WMS GetFeatureInfo) arrive
+      // asynchronously; wait for all of them before inspecting.
+      await pickedFeatures.allFeaturesAvailablePromise;
+      if (seq !== clickSeq) return;
+
+      const now = JulianDate.now();
+      const matchedFeature = pickedFeatures.features.find(
+        (f) => f.properties?.getValue(now)?.[URL_ATTRIBUTE]
+      );
+
+      if (!matchedFeature) {
+        // Don't remove the dynamic layer when the user is inspecting it -
+        // its own features won't carry a wms_url attribute.
+        const clickedDynamicLayer =
+          currentItem !== undefined &&
+          pickedFeatures.features.some((f) =>
+            featureBelongsToCatalogItem(f, currentItem!)
+          );
+        if (!clickedDynamicLayer) {
+          removeCurrent();
+        }
+        return;
+      }
+
+      const props = matchedFeature.properties!.getValue(now);
+      const wmsUrl: string = String(props[URL_ATTRIBUTE]);
+      const wmsLayer: string =
+        props[LAYER_ATTRIBUTE] !== undefined
+          ? String(props[LAYER_ATTRIBUTE])
+          : "";
+      const wmsName: string =
+        props[NAME_ATTRIBUTE] !== undefined
+          ? String(props[NAME_ATTRIBUTE])
+          : "Feature Layer";
+
+      if (wmsLayer === "") {
+        console.warn(
+          `DynamicWms: feature has ${URL_ATTRIBUTE} but no ${LAYER_ATTRIBUTE}; the WMS layer may not load.`
+        );
+      }
+
+      // Clicking the same feature (or one pointing at the same layer) again
+      // shouldn't reload the layer.
+      if (
+        currentItem &&
+        terria.workbench.contains(currentItem) &&
+        currentItem.url === wmsUrl &&
+        currentItem.layers === wmsLayer
+      ) {
+        return;
+      }
+
+      removeCurrent();
+
+      if (!currentItem) {
+        currentItem = new WebMapServiceCatalogItem(DYNAMIC_WMS_ID, terria);
+      }
+      currentItem.setTrait(CommonStrata.user, "url", wmsUrl);
+      currentItem.setTrait(CommonStrata.user, "layers", wmsLayer);
+      currentItem.setTrait(CommonStrata.user, "name", wmsName);
+
+      const result = await terria.workbench.add(currentItem);
+      if (seq !== clickSeq) {
+        // A newer click happened while the layer was loading; that click's
+        // handler owns the workbench now.
+        return;
+      }
+      result.raiseError(terria, `Failed to load WMS layer "${wmsName}"`);
+    }
+
     reaction(
       () => terria.pickedFeatures,
-      async (pickedFeatures) => {
-        if (!pickedFeatures) {
-          removeCurrent();
-          return;
-        }
-
-        await pickedFeatures.allFeaturesAvailablePromise;
-
-        // Guard against a newer click having already replaced pickedFeatures
-        if (terria.pickedFeatures !== pickedFeatures) return;
-
-        const now = JulianDate.now();
-        const matchedFeature = pickedFeatures.features.find(
-          (f) => f.properties?.getValue(now)?.wms_url
-        );
-
-        if (!matchedFeature) {
-          removeCurrent();
-          return;
-        }
-
-        const props = matchedFeature.properties!.getValue(now);
-        const wmsUrl: string = props.wms_url;
-        const wmsLayer: string = props.wms_layer ?? "";
-        const wmsName: string = props.wms_name ?? "Feature Layer";
-
-        removeCurrent();
-
-        if (!currentItem) {
-          currentItem = new WebMapServiceCatalogItem(DYNAMIC_WMS_ID, terria);
-        }
-        currentItem.setTrait(CommonStrata.user, "url", wmsUrl);
-        currentItem.setTrait(CommonStrata.user, "layers", wmsLayer);
-        currentItem.setTrait(CommonStrata.user, "name", wmsName);
-
-        await terria.workbench.add(currentItem);
+      (pickedFeatures) => {
+        onPickedFeatures(pickedFeatures).catch((e) => {
+          TerriaError.from(e, {
+            title: "DynamicWms plugin error"
+          }).log();
+        });
       }
     );
   }

--- a/lib/Plugins/DynamicWmsPlugin.ts
+++ b/lib/Plugins/DynamicWmsPlugin.ts
@@ -1,0 +1,66 @@
+import { reaction } from "mobx";
+import { JulianDate } from "@cesium/engine";
+import CommonStrata from "terriajs/lib/Models/Definition/CommonStrata";
+import WebMapServiceCatalogItem from "terriajs/lib/Models/Catalog/Ows/WebMapServiceCatalogItem";
+import type { TerriaPluginContext } from "terriajs-plugin-api";
+
+const DYNAMIC_WMS_ID = "__re100_dynamic_wms__";
+
+export default {
+  name: "DynamicWms",
+  description:
+    "Loads a WMS layer into the workbench when a feature with a wms_url attribute is clicked, and removes it when another feature (without wms_url) is clicked.",
+  version: "1.0.0",
+
+  register(ctx: TerriaPluginContext) {
+    const { terria } = ctx;
+    let currentItem: WebMapServiceCatalogItem | undefined;
+
+    function removeCurrent() {
+      if (currentItem && terria.workbench.contains(currentItem)) {
+        terria.workbench.remove(currentItem);
+      }
+    }
+
+    reaction(
+      () => terria.pickedFeatures,
+      async (pickedFeatures) => {
+        if (!pickedFeatures) {
+          removeCurrent();
+          return;
+        }
+
+        await pickedFeatures.allFeaturesAvailablePromise;
+
+        // Guard against a newer click having already replaced pickedFeatures
+        if (terria.pickedFeatures !== pickedFeatures) return;
+
+        const now = JulianDate.now();
+        const matchedFeature = pickedFeatures.features.find(
+          (f) => f.properties?.getValue(now)?.wms_url
+        );
+
+        if (!matchedFeature) {
+          removeCurrent();
+          return;
+        }
+
+        const props = matchedFeature.properties!.getValue(now);
+        const wmsUrl: string = props.wms_url;
+        const wmsLayer: string = props.wms_layer ?? "";
+        const wmsName: string = props.wms_name ?? "Feature Layer";
+
+        removeCurrent();
+
+        if (!currentItem) {
+          currentItem = new WebMapServiceCatalogItem(DYNAMIC_WMS_ID, terria);
+        }
+        currentItem.setTrait(CommonStrata.user, "url", wmsUrl);
+        currentItem.setTrait(CommonStrata.user, "layers", wmsLayer);
+        currentItem.setTrait(CommonStrata.user, "name", wmsName);
+
+        await terria.workbench.add(currentItem);
+      }
+    );
+  }
+};

--- a/plugins.ts
+++ b/plugins.ts
@@ -4,8 +4,7 @@ import { TerriaPluginModule } from "terriajs-plugin-api";
  * A function that when called imports all plugins.
  */
 const plugins: () => Promise<TerriaPluginModule>[] = () => [
-  // Add plugin imports. Example:
-  // import("terriajs-plugin-sample"),
+  import("./lib/Plugins/DynamicWmsPlugin") as Promise<TerriaPluginModule>
 ];
 
 export default plugins;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "lib/**/*.tsx",
     "lib/**/*.js",
     "lib/**/*.jsx",
-    "types/**/*.d.ts"
+    "types/**/*.d.ts",
+    "node_modules/terriajs/lib/ThirdParty/terriajs-cesium-extra/index.d.ts"
   ]
 }


### PR DESCRIPTION
Merging new plugin for dynamic WMS layer loading on clicking features. Features with the attributes "wms_url", "wms_layer", and "wms_name" will dynamically add the referenced WMS layer to the workbench when clicked. Closing the feature box or clicking outside the dynamically loaded layer will unload it automatically. Primarily required for PVDEH to dynamically load heatmaps for each facility, since these heatmaps may overlap with each other for nearby facilities.